### PR TITLE
Drop support for Laravel 10 and 11, add support for Laravel 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.4]
-                laravel: [10.*, 11.*, 12.*]
+                laravel: [12.*, 13.*]
                 os: [ubuntu-latest]
                 coverage: [none]
                 include:
                     - php: 8.4
-                      laravel: 12.*
+                      laravel: 13.*
                       os: ubuntu-latest
                       coverage: xdebug
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Stable Version](https://img.shields.io/packagist/v/aporat/laravel-rate-limiter.svg?style=flat-square&logo=composer)](https://packagist.org/packages/aporat/laravel-rate-limiter)
 [![Downloads](https://img.shields.io/packagist/dt/aporat/laravel-rate-limiter.svg?style=flat-square&logo=composer)](https://packagist.org/packages/aporat/laravel-rate-limiter)
 [![Codecov](https://img.shields.io/codecov/c/github/aporat/laravel-rate-limiter?style=flat-square)](https://codecov.io/github/aporat/laravel-rate-limiter)
-[![Laravel Version](https://img.shields.io/badge/Laravel-12.x-orange.svg?style=flat-square)](https://laravel.com/docs/12.x)
+[![Laravel Version](https://img.shields.io/badge/Laravel-13.x-orange.svg?style=flat-square)](https://laravel.com/docs/13.x)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/aporat/laravel-rate-limiter/ci.yml?style=flat-square)
 [![License](https://img.shields.io/packagist/l/aporat/laravel-rate-limiter.svg?style=flat-square)](https://github.com/aporat/laravel-rate-limiter/blob/master/LICENSE)
 
@@ -18,7 +18,7 @@ A flexible rate limiting middleware for Laravel applications, designed to thrott
 
 ## Requirements
 - **PHP**: 8.4 or higher
-- **Laravel**: 10.x, 11.x or 12.x
+- **Laravel**: 12.x or 13.x
 - **Redis**: Required for storage (ext-redis extension)
 - **Composer**: Required for installation
 

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
         "php": "^8.4",
         "ext-json": "*",
         "ext-redis": "*",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/http": "^10.0 || ^11.0 || ^12.0"
+        "illuminate/support": "^12.0 || ^13.0",
+        "illuminate/http": "^12.0 || ^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.21",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.0 || ^12.0"
     },

--- a/tests/RateLimiterExceptionTriggerTest.php
+++ b/tests/RateLimiterExceptionTriggerTest.php
@@ -23,7 +23,7 @@ class RateLimiterExceptionTriggerTest extends TestCase
     protected function tearDown(): void
     {
         // Clean up Redis keys after test
-        $redis = new \Redis;
+        $redis = new Redis;
         $redis->connect('127.0.0.1', 6379);
         $redis->select(15);
         foreach ($redis->keys('test-rate-limiter*') as $key) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
 // Enable Composer autoloader
 /** @var \Composer\Autoload\ClassLoader $autoloader */
 require __DIR__.'/../vendor/autoload.php';
+


### PR DESCRIPTION
## Summary
This PR updates the package to drop support for Laravel 10 and 11, and adds support for the newly released Laravel 13. The minimum supported Laravel version is now 12.x.

## Key Changes
- Updated `illuminate/support` and `illuminate/http` dependencies from `^10.0 || ^11.0 || ^12.0` to `^12.0 || ^13.0`
- Updated `orchestra/testbench` dev dependency from `^8.0 || ^9.0 || ^10.0` to `^10.0 || ^11.0`
- Updated CI workflow to test against Laravel 12.x and 13.x (removed 10.x and 11.x)
- Updated coverage build to use Laravel 13.x instead of 12.x
- Updated README to reflect Laravel 13.x as the primary supported version and updated requirements section

## Notes
- PHP 8.4 remains the minimum required PHP version
- All other dependencies remain unchanged

https://claude.ai/code/session_01Ma9KCKpLCebPcwZsKktiMh